### PR TITLE
Add clearer guidance for running the container locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
  build:
   # Variable expansion in working_directory not supported at this time
   # You will need to modify the code below to reflect your github account/repo setup
-  working_directory: /go/src/github.com/Securing-DevOps/invoicer-chapter2
+  working_directory: /go/src/github.com/zacsketches/invoicer-chapter2
   docker:
    - image: circleci/golang:1.10
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
  build:
   # Variable expansion in working_directory not supported at this time
   # You will need to modify the code below to reflect your github account/repo setup
-  working_directory: /go/src/github.com/zacsketches/invoicer-chapter2
+  working_directory: /go/src/github.com/<YourGitHubUsername>/invoicer-chapter2
   docker:
    - image: circleci/golang:1.10
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
  build:
   # Variable expansion in working_directory not supported at this time
   # You will need to modify the code below to reflect your github account/repo setup
-  working_directory: /go/src/github.com/<YourGitHubUsername>/invoicer-chapter2
+  working_directory: /go/src/github.com/zacsketches/invoicer-chapter2
   docker:
    - image: circleci/golang:1.10
   steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 invoicer.db
+bin/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+invoicer.db

--- a/README.md
+++ b/README.md
@@ -43,11 +43,19 @@ These variable will allow CircleCI to upload the docker container of the
 invoicer into your own account. Once added, trigger a rebuild of the CircleCI
 job and it should succeed and upload the container without issue.
 
-You can then pull and run the container from your repository as follows:
+You can then pull and run the container from your repository and run it locally.  The `-it` flag keeps the log for the container open in the terminal window.  The `-p 8080:8080` flag connects the host port 8080 to the container port 8080.  Note in the `main.go` file on line 81 that the go microservice calls `ListenAndServe` on port 8080.
 
 ```bash
-$ docker run -it <MyGitHubUser>/invoicer
+$ docker run -it -p 8080:8080 <MyGitHubUser>/invoicer
 ```
+
+Once the container is running open another terminal window and test that the heartbeat is returned from the application by calling the heartbeat API endpoint.
+
+```
+curl localhost:8080/__heartbeat__
+```
+
+Now you know the container will properly build and that the invoicer is ready to work.  So let's move to deploying it into the cloud.
 
 Build the AWS infrastructure
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ job and it should succeed and upload the container without issue.
 You can then pull and run the container from your repository and run it locally.  The `-it` flag keeps the log for the container open in the terminal window.  The `-p 8080:8080` flag connects the host port 8080 to the container port 8080.  Note in the `main.go` file on line 81 that the go microservice calls `ListenAndServe` on port 8080.
 
 ```bash
-$ docker run -it -p 8080:8080 <MyGitHubUser>/invoicer
+$ docker run -it -p 8080:8080 <MyDockerHubUsername>/invoicer
 ```
 
 Once the container is running open another terminal window and test that the heartbeat is returned from the application by calling the heartbeat API endpoint.


### PR DESCRIPTION
This pull request adds some more clarity for running the container locally before building the AWS infrastructure. It includes updates to README.md and add a .gitignore so that the database created when running the code locally does not get included in version control.

BTW - loving the book so far. Just thought I'd help out a little bit. I'm having one of our junior cloud architects work through this book so I wanted to make a few things clearer that I think might help them.